### PR TITLE
Merge issue-3 into dev-vnext

### DIFF
--- a/src/AvConsoleToolkit/Commands/Crestron/Program/ProgramUploadCommand.cs
+++ b/src/AvConsoleToolkit/Commands/Crestron/Program/ProgramUploadCommand.cs
@@ -118,7 +118,7 @@ namespace AvConsoleToolkit.Commands.Crestron.Program
 
                 var remotePath = $"program{settings.Slot:D2}";
 
-                AnsiConsole.MarkupLineInterpolated($"[teal]Uploading {settings.ProgramFile} to slot {settings.Slot} on device '{settings.Host}'...[/]");
+                AnsiConsole.MarkupLineInterpolated($"[teal]Uploading {Path.GetFileName(settings.ProgramFile)} to slot {settings.Slot} on device '{settings.Host}'...[/]");
 
                 // .clz files must always be extracted and uploaded as individual files
                 // because they are not full program packages that can be loaded directly


### PR DESCRIPTION
… extracted and uploaded when provided, regardless of whether the `-c` flag was present. Now a `clz` file will always be extracted for uploading. All the files will be uploaded individually when no `-c` flag is present.